### PR TITLE
feat: Showing Product Details Page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react-dom": "^18",
         "react-hook-form": "^7.53.0",
         "sonner": "^1.5.0",
+        "swiper": "^11.1.14",
         "tailwind-merge": "^2.5.2",
         "zod": "^3.23.8"
       },
@@ -14786,6 +14787,25 @@
       "peerDependencies": {
         "@swc/core": "^1.0.0",
         "webpack": "^5.0.0"
+      }
+    },
+    "node_modules/swiper": {
+      "version": "11.1.14",
+      "resolved": "https://registry.npmjs.org/swiper/-/swiper-11.1.14.tgz",
+      "integrity": "sha512-VbQLQXC04io6AoAjIUWuZwW4MSYozkcP9KjLdrsG/00Q/yiwvhz9RQyt0nHXV10hi9NVnDNy1/wv7Dzq1lkOCQ==",
+      "funding": [
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/swiperjs"
+        },
+        {
+          "type": "open_collective",
+          "url": "http://opencollective.com/swiper"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.7.0"
       }
     },
     "node_modules/tabbable": {

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "react-dom": "^18",
     "react-hook-form": "^7.53.0",
     "sonner": "^1.5.0",
+    "swiper": "^11.1.14",
     "tailwind-merge": "^2.5.2",
     "zod": "^3.23.8"
   },

--- a/src/app/sneakers/[productId]/page.tsx
+++ b/src/app/sneakers/[productId]/page.tsx
@@ -47,28 +47,21 @@ const Page = async ({ params }: PageProps) => {
   return (
     <MainContainer className="flex flex-col gap-8 py-6">
       <div className="flex flex-col gap-y-6 lg:flex-row lg:gap-x-10">
-        {/* Left Column */}
         <div className="flex flex-col gap-4 lg:w-[60%] xl:w-2/3">
-          {/* Breadcrumbs */}
           <Breadcrumbs items={breadcrumbs} className="hidden sm:block" />
 
-          {/* Product Details */}
           <div className="lg:hidden">
             <ProductDetails product={product} />
           </div>
 
-          {/* Image Slider */}
           <ImageSlider urls={validUrls} />
         </div>
 
-        {/* Right Column */}
         <div className="flex flex-col gap-4 lg:w-[40%] lg:justify-between xl:w-1/3 xl:gap-8">
-          {/* Product Details */}
           <div className="hidden lg:block">
             <ProductDetails product={product} />
           </div>
 
-          {/* Available Sizes */}
           <ProductSizes
             category={product.category}
             availableSizes={product.available_sizes}

--- a/src/app/sneakers/[productId]/page.tsx
+++ b/src/app/sneakers/[productId]/page.tsx
@@ -1,0 +1,89 @@
+import Breadcrumbs, { BreadcrumbItem } from "@/components/base/Breadcrumbs";
+import ImageSlider from "@/components/ImageSlider";
+import MainContainer from "@/components/MainContainer";
+import ProductDetails from "@/components/product/ProductDetails";
+import ProductInfo from "@/components/product/ProductInfo";
+import ProductReel from "@/components/product/ProductReel";
+import ProductSizes from "@/components/product/ProductSizes";
+import { getPayloadClient } from "@/get-payload";
+import { Product } from "@/types/payload";
+import { getProductInfo } from "@/utils/product";
+import { notFound } from "next/navigation";
+
+interface PageProps {
+  params: {
+    productId: string;
+  };
+}
+
+const Page = async ({ params }: PageProps) => {
+  const { productId } = params;
+
+  const payload = await getPayloadClient();
+  const { docs: products } = await payload.find({
+    collection: "products",
+    limit: 1,
+    where: {
+      id: { equals: productId },
+    },
+  });
+
+  const [product] = products as unknown as Product[];
+  if (!product) return notFound();
+
+  const { brand, model } = getProductInfo(product);
+
+  const validUrls = product.images
+    .map(({ image }) => (typeof image === "string" ? image : image.url))
+    .filter(Boolean) as string[];
+
+  const breadcrumbs: BreadcrumbItem[] = [
+    { label: "Sneakers", href: "/sneakers" },
+    { label: `${brand} Shoes`, href: `/sneakers?brand=${brand}` },
+    { label: `${model}`, href: `/sneakers?brand=${brand}&model=${model}` },
+    { label: `${product.nickname}` },
+  ];
+
+  return (
+    <MainContainer className="flex flex-col gap-8 py-6">
+      <div className="flex flex-col gap-y-6 lg:flex-row lg:gap-x-10">
+        {/* Left Column */}
+        <div className="flex flex-col gap-4 lg:w-[60%] xl:w-2/3">
+          {/* Breadcrumbs */}
+          <Breadcrumbs items={breadcrumbs} className="hidden sm:block" />
+
+          {/* Product Details */}
+          <div className="lg:hidden">
+            <ProductDetails product={product} />
+          </div>
+
+          {/* Image Slider */}
+          <ImageSlider urls={validUrls} />
+        </div>
+
+        {/* Right Column */}
+        <div className="flex flex-col gap-4 lg:w-[40%] lg:justify-between xl:w-1/3 xl:gap-8">
+          {/* Product Details */}
+          <div className="hidden lg:block">
+            <ProductDetails product={product} />
+          </div>
+
+          {/* Available Sizes */}
+          <ProductSizes
+            category={product.category}
+            availableSizes={product.available_sizes}
+          />
+        </div>
+      </div>
+
+      <ProductInfo product={product} />
+
+      <ProductReel
+        query={{ sort: "desc", limit: 6 }}
+        title="Related Sneakers"
+      />
+    </MainContainer>
+  );
+};
+
+export default Page;

--- a/src/components/ImageSlider.tsx
+++ b/src/components/ImageSlider.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { cn } from "@/utils";
+import { Icon } from "@iconify/react";
+import Image from "next/image";
+import { useEffect, useState } from "react";
+import type SwiperType from "swiper";
+import "swiper/css";
+import "swiper/css/pagination";
+import { Keyboard, Navigation, Pagination } from "swiper/modules";
+import { Swiper, SwiperSlide } from "swiper/react";
+
+interface ImageSliderProps {
+  urls: string[];
+}
+
+const ImageSlider = ({ urls }: ImageSliderProps) => {
+  const [swiper, setSwiper] = useState<null | SwiperType>(null);
+  const [activeIndex, setActiveIndex] = useState(0);
+
+  const [slideConfig, setSlideConfig] = useState({
+    isBeginning: true,
+    isEnd: activeIndex === (urls.length ?? 0) - 1,
+  });
+
+  useEffect(() => {
+    swiper?.on("slideChange", ({ activeIndex }) => {
+      setActiveIndex(activeIndex);
+      setSlideConfig({
+        isBeginning: activeIndex === 0,
+        isEnd: activeIndex === (urls.length ?? 0) - 1,
+      });
+    });
+  }, [swiper, urls]);
+
+  return (
+    <div className="relative flex-1 aspect-square sm:aspect-video lg:aspect-square xl:aspect-video overflow-hidden rounded-2xl">
+      <button
+        aria-label="previous image"
+        onClick={(e) => {
+          e.preventDefault();
+          swiper?.slidePrev();
+        }}
+        className={cn(
+          "hidden sm:block absolute inset-y-0 left-0 z-10 p-2 transition backdrop-blur-lg bg-background/30",
+          {
+            "opacity-40 cursor-default": slideConfig.isBeginning,
+          }
+        )}
+      >
+        <Icon icon="mage:chevron-left" className="h-6 w-6 text-primary-700" />
+      </button>
+      <Swiper
+        spaceBetween={50}
+        slidesPerView={1}
+        className="h-full w-full"
+        onSwiper={(swiper) => setSwiper(swiper)}
+        modules={[Pagination, Keyboard, Navigation]}
+        keyboard={{
+          enabled: true,
+        }}
+        navigation={true}
+        grabCursor={true}
+        pagination={{
+          clickable: true,
+          renderBullet: (_, className) => {
+            return `<span class="rounded-full transition-all ease-in-out duration-300 ${className}"></span>`;
+          },
+        }}
+        style={
+          {
+            "--swiper-pagination-color": "#212427",
+            "--swiper-pagination-bullet-inactive-color": "#EBEBEB",
+            "--swiper-pagination-bullet-inactive-opacity": "1",
+            "--swiper-pagination-bullet-size": "0.5rem",
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          } as any
+        }
+      >
+        {urls.map((url, i) => (
+          <SwiperSlide key={i} className="h-full w-full">
+            <Image
+              fill
+              loading="eager"
+              className="-z-10 h-full w-full object-center object-contain"
+              src={url}
+              priority={true}
+              alt="Product image"
+            />
+          </SwiperSlide>
+        ))}
+      </Swiper>
+      <button
+        aria-label="next image"
+        onClick={(e) => {
+          e.preventDefault();
+          swiper?.slideNext();
+        }}
+        className={cn(
+          "hidden sm:block absolute inset-y-0 right-0 z-10 p-2 transition backdrop-blur-lg bg-background/30",
+          {
+            "opacity-40 cursor-default": slideConfig.isEnd,
+          }
+        )}
+      >
+        <Icon icon="mage:chevron-right" className="h-6 w-6 text-primary-700" />
+      </button>
+    </div>
+  );
+};
+
+export default ImageSlider;

--- a/src/components/MainContainer.tsx
+++ b/src/components/MainContainer.tsx
@@ -10,7 +10,7 @@ const MainContainer = ({
 }) => {
   return (
     <div
-      className={cn("mx-auto w-full max-w-screen-2xl px-8 2xl:px-0", className)}
+      className={cn("mx-auto w-full max-w-screen-2xl px-8 3xl:px-0", className)}
     >
       {children}
     </div>

--- a/src/components/base/Accordion.tsx
+++ b/src/components/base/Accordion.tsx
@@ -39,7 +39,7 @@ const AccordionItem = ({
 
   return (
     <>
-      {content ? (
+      {content && title && (
         <div className="w-full">
           <div
             className="flex justify-between items-center rounded-2xl cursor-pointer px-4 py-3 hover:bg-primary-100"
@@ -49,14 +49,12 @@ const AccordionItem = ({
               {icon && <Icon icon={icon} height="1.5rem" />}
               <h4 className="font-semibold text-lg">{title}</h4>
             </div>
-
             <span
               className={`transition-transform duration-300 ease-in-out ${isOpen ? "rotate-90" : "rotate-0"}`}
             >
               <Icon icon="mage:chevron-down" height="1.5rem" />
             </span>
           </div>
-
           <div
             ref={contentRef}
             className={`overflow-hidden transition-all duration-300 ease-in-out`}
@@ -67,7 +65,7 @@ const AccordionItem = ({
             </p>
           </div>
         </div>
-      ) : null}
+      )}
     </>
   );
 };

--- a/src/components/base/Accordion.tsx
+++ b/src/components/base/Accordion.tsx
@@ -1,0 +1,101 @@
+"use client";
+
+import { Icon } from "@iconify/react";
+import { useEffect, useRef, useState } from "react";
+
+export interface AccordionItem {
+  title: string;
+  icon?: string;
+  content: string;
+}
+
+interface AccordionItemProps extends AccordionItem {
+  isOpen?: boolean;
+  onOpen?: () => void;
+}
+
+interface AccordionProps {
+  items: AccordionItem[];
+  activeIndex?: number;
+}
+
+const AccordionItem = ({
+  title,
+  icon,
+  content,
+  isOpen,
+  onOpen,
+}: AccordionItemProps) => {
+  const contentRef = useRef<HTMLDivElement>(null);
+  const [height, setHeight] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (isOpen && contentRef.current) {
+      setHeight(`${contentRef.current.scrollHeight}px`);
+    } else {
+      setHeight("0px");
+    }
+  }, [isOpen]);
+
+  return (
+    <>
+      {content ? (
+        <div className="w-full">
+          <div
+            className="flex justify-between items-center rounded-2xl cursor-pointer px-4 py-3 hover:bg-primary-100"
+            onClick={onOpen}
+          >
+            <div className="flex items-center gap-3">
+              {icon && <Icon icon={icon} height="1.5rem" />}
+              <h4 className="font-semibold text-lg">{title}</h4>
+            </div>
+
+            <span
+              className={`transition-transform duration-300 ease-in-out ${isOpen ? "rotate-90" : "rotate-0"}`}
+            >
+              <Icon icon="mage:chevron-down" height="1.5rem" />
+            </span>
+          </div>
+
+          <div
+            ref={contentRef}
+            className={`overflow-hidden transition-all duration-300 ease-in-out`}
+            style={{ height }}
+          >
+            <p className="px-4 py-1 bg-background text-primary-700 text-justify text-md sm:text-base">
+              {content}
+            </p>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+};
+
+const Accordion = ({ items, activeIndex }: AccordionProps) => {
+  const [openIndex, setOpenIndex] = useState<number | null>(
+    activeIndex ?? null
+  );
+
+  const handleToggle = (index: number) => {
+    setOpenIndex(openIndex === index ? null : index);
+  };
+
+  return (
+    <ul className="w-full flex flex-col gap-4 3xl:gap-2">
+      {items.map((item, index) => (
+        <li key={index}>
+          <AccordionItem
+            title={item.title}
+            icon={item.icon}
+            content={item.content}
+            isOpen={openIndex === index}
+            onOpen={() => handleToggle(index)}
+          />
+        </li>
+      ))}
+    </ul>
+  );
+};
+
+export default Accordion;

--- a/src/components/base/Breadcrumbs.tsx
+++ b/src/components/base/Breadcrumbs.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+import { ComponentPropsWithoutRef } from "react";
+
+export interface BreadcrumbItem {
+  label: string;
+  href?: string;
+}
+
+interface BreadcrumbsProps extends ComponentPropsWithoutRef<"div"> {
+  items: BreadcrumbItem[];
+}
+
+const Breadcrumbs = ({ items, className }: BreadcrumbsProps) => {
+  return (
+    <div className={className}>
+      <ol className="flex items-center gap-4">
+        {items.map((breadcrumb, index) => (
+          <li key={breadcrumb.href}>
+            <div className="flex items-center font-semibold text-sm sm:text-md">
+              {breadcrumb.href ? (
+                <Link
+                  href={breadcrumb.href}
+                  className="text-primary-400 hover:text-foreground cursor-pointer"
+                >
+                  {breadcrumb.label}
+                </Link>
+              ) : (
+                <p className="text-foreground font-bold">{breadcrumb.label}</p>
+              )}
+              {index !== items.length - 1 && (
+                <span className="w-px h-5 bg-primary-400 ml-4" />
+              )}
+            </div>
+          </li>
+        ))}
+      </ol>
+    </div>
+  );
+};
+
+export default Breadcrumbs;

--- a/src/components/home/PerksSection.tsx
+++ b/src/components/home/PerksSection.tsx
@@ -53,6 +53,7 @@ const PerkCard = ({ icon, title, description }: PerkItem) => {
   );
 };
 
+// TODO: Remove the MainContainer from here
 const PerksSection = () => {
   return (
     <section>

--- a/src/components/nav/Navbar.tsx
+++ b/src/components/nav/Navbar.tsx
@@ -14,7 +14,7 @@ const Navbar = async () => {
 
   return (
     <div className="sticky z-10 top-0 inset-x-0">
-      <header className="relative bg-background ">
+      <header className="relative bg-background shadow">
         <MainContainer>
           <div className="flex gap-20 py-6 items-center">
             {/* TODO: Mobile nav */}

--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -85,7 +85,7 @@ const ProductCard = ({
       })}
     >
       <div className="flex flex-col gap-2 w-full">
-        <div className="relative px-5 bg-zinc-100 rounded-2xl">
+        <div className="relative px-5 bg-zinc-100 rounded-2xl aspect-square sm:aspect-auto">
           {showWishlist && (
             <Icon
               icon="solar:bookmark-bold-duotone"
@@ -99,11 +99,11 @@ const ProductCard = ({
             width={400}
             height={300}
             loading="eager"
-            className="h-full w-full object-cover object-center mix-blend-multiply transition-transform duration-300 ease-in-out group-hover:scale-105"
+            className="h-full w-full object-contain mix-blend-multiply transition-transform duration-300 ease-in-out group-hover:scale-105"
           />
         </div>
         <div className="flex flex-col w-full">
-          <h3 className="font-semibold text-primary-800 text-md sm:text-base">
+          <h3 className="font-semibold text-primary-800 line-clamp-1 sm:text-base">
             {product.nickname}
           </h3>
           <span className="flex items-center gap-2 text-primary-500">

--- a/src/components/product/ProductCard.tsx
+++ b/src/components/product/ProductCard.tsx
@@ -1,13 +1,14 @@
 "use client";
 
 import { Product } from "@/types/payload";
+import { cn, formatPrice } from "@/utils";
+import { getPriceInfo, getProductInfo } from "@/utils/product";
+import { Icon } from "@iconify/react";
+import Image from "next/image";
+import Link from "next/link";
 import { useEffect, useState } from "react";
 import ProductSkeleton from "../skeletons/ProductSkeleton";
-import { cn, formatPrice } from "@/utils";
-import Link from "next/link";
-import Image from "next/image";
 import BrandLogo from "./BrandLogo";
-import { Icon } from "@iconify/react";
 
 interface ProductCardProps {
   product: Product | null;
@@ -39,43 +40,8 @@ const ProductCard = ({
       : (firstImage.sizes?.thumbnail?.url as string);
   };
 
-  const getPriceInfo = () => {
-    const minPriceInfo = product.available_sizes.reduce(
-      (min, size) => {
-        const regularPrice = size.price ?? Infinity;
-        const discountedPrice = size.discount
-          ? regularPrice * (1 - size.discount)
-          : regularPrice;
-
-        if (discountedPrice < min.discountedPrice) {
-          return { regularPrice, discountedPrice };
-        }
-
-        return min;
-      },
-      { regularPrice: Infinity, discountedPrice: Infinity }
-    );
-
-    return {
-      regularPrice: minPriceInfo.regularPrice,
-      discountedPrice:
-        minPriceInfo.discountedPrice !== minPriceInfo.regularPrice
-          ? minPriceInfo.discountedPrice
-          : null,
-    };
-  };
-
-  const getProductInfo = () => {
-    const brand =
-      typeof product.brand === "string" ? product.brand : product.brand.name;
-    const model =
-      typeof product.model === "string" ? product.model : product.model.name;
-
-    return { brand, model };
-  };
-
-  const { regularPrice, discountedPrice } = getPriceInfo();
-  const { brand, model } = getProductInfo();
+  const { regularPrice, discountedPrice } = getPriceInfo(product);
+  const { brand, model } = getProductInfo(product);
 
   return (
     <Link

--- a/src/components/product/ProductDetails.tsx
+++ b/src/components/product/ProductDetails.tsx
@@ -1,0 +1,40 @@
+import { Product } from "@/types/payload";
+import { formatPrice } from "@/utils";
+import { getPriceInfo, getProductInfo } from "@/utils/product";
+import BrandLogo from "./BrandLogo";
+
+interface ProductDetailsProps {
+  product: Product;
+}
+
+const ProductDetails = ({ product }: ProductDetailsProps) => {
+  const { regularPrice } = getPriceInfo(product);
+  const { brand, model } = getProductInfo(product);
+
+  return (
+    <div className="flex flex-col gap-4 lg:gap-6">
+      <div className="flex flex-col lg:gap-2">
+        <div className="flex items-center gap-2 text-primary-600 text-md sm:text-base">
+          <BrandLogo brand={brand} />
+          <h3 className="font-medium">{brand}</h3>
+        </div>
+
+        <div className="flex flex-col">
+          <h1 className="font-bold text-2xl lg:text-3xl">{model}</h1>
+          <h2 className="font-medium text-xl">
+            &quot;{product.nickname}&quot;
+          </h2>
+        </div>
+      </div>
+
+      <div className="flex items-baseline gap-1">
+        <h1 className="font-semibold text-2xl lg:font-bold">
+          {formatPrice(regularPrice)}
+        </h1>
+        <span>& up</span>
+      </div>
+    </div>
+  );
+};
+
+export default ProductDetails;

--- a/src/components/product/ProductInfo.tsx
+++ b/src/components/product/ProductInfo.tsx
@@ -1,0 +1,112 @@
+import { Product } from "@/types/payload";
+import { cn, formatPrice } from "@/utils";
+import { formatCategory, getProductInfo } from "@/utils/product";
+import { format } from "date-fns";
+import Accordion, { AccordionItem } from "../base/Accordion";
+
+interface ProductInfoProps {
+  product: Product;
+}
+
+const ProductInfo = ({ product }: ProductInfoProps) => {
+  const { brand } = getProductInfo(product);
+
+  const hasDescription = !!product.description;
+
+  const releaseDate = product.release_date
+    ? format(new Date(product.release_date as string), "MM/dd/yyyy")
+    : "-";
+
+  const productInfo = [
+    { label: "Manufactured SKU", value: product.sku },
+    { label: "Brand", value: brand },
+    { label: "Colorway", value: product.colorway },
+    { label: "Gender", value: formatCategory(product.category) },
+    { label: "Retail Price", value: formatPrice(product.retail_price) },
+    { label: "Release Date", value: releaseDate },
+  ];
+
+  const accordionItems: AccordionItem[] = [
+    {
+      title: "Sneaker Description",
+      icon: "hugeicons:running-shoes",
+      content: product.description as string,
+    },
+    {
+      title: "Authenticity Guarantee",
+      icon: "solar:shield-check-outline",
+      content:
+        "Every sneaker we sell undergoes meticulous inspection by our expert team, comprised of the industry's most seasoned and highly trained authenticators.",
+    },
+    {
+      title: "Returns Accepted",
+      icon: "fad:undo",
+      content:
+        "Our straightforward returns policy ensures a hassle-free experience. Reach out to our support team, and we'll guide you through the process, prioritizing your peace of mind.",
+    },
+  ];
+
+  const renderProductInfo = () => (
+    <ul
+      className={cn(
+        "h-full grid grid-cols-2 md:grid-cols-3 gap-y-6 gap-x-8 px-6 py-4 bg-primary-100 rounded-2xl",
+        { "3xl:flex 3xl:justify-between": hasDescription }
+      )}
+    >
+      {productInfo.map((data, index) => (
+        <li
+          key={index}
+          className={cn("flex items-start", {
+            "col-span-2 md:col-span-1": data.label === "Colorway",
+            "hidden md:block": data.label === "Gender",
+          })}
+        >
+          <div className="flex flex-col">
+            <span className="font-semibold text-md text-primary-500">
+              {data.label}
+            </span>
+            <span className="font-medium text-primary-700">{data.value}</span>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+
+  const renderAccordions = () => (
+    <>
+      <div className="hidden lg:flex lg:gap-x-10">
+        <div className="lg:w-[60%] xl:w-2/3">
+          {hasDescription ? (
+            <>
+              <h4 className="py-3 font-semibold text-lg">
+                {accordionItems[0].title}
+              </h4>
+              <p className="py-1 bg-background text-primary-700 text-justify text-md sm:text-base leading-7">
+                {accordionItems[0].content}
+              </p>
+            </>
+          ) : (
+            renderProductInfo()
+          )}
+        </div>
+        <div className="lg:w-[40%] xl:w-1/3">
+          <Accordion items={accordionItems.slice(1)} activeIndex={0} />
+        </div>
+      </div>
+      <div className="lg:hidden">
+        <Accordion items={accordionItems} />
+      </div>
+    </>
+  );
+
+  return (
+    <div className="flex flex-col gap-6">
+      <div className={cn({ "lg:hidden": !hasDescription })}>
+        {renderProductInfo()}
+      </div>
+      {renderAccordions()}
+    </div>
+  );
+};
+
+export default ProductInfo;

--- a/src/components/product/ProductReel.tsx
+++ b/src/components/product/ProductReel.tsx
@@ -7,6 +7,7 @@ import { Icon } from "@iconify/react";
 import Link from "next/link";
 import ProductCard from "./ProductCard";
 import { useMemo } from "react";
+import { cn } from "@/utils";
 
 interface ProductReelProps {
   title: string;
@@ -44,10 +45,10 @@ const ProductReel = (props: ProductReelProps) => {
   }, [productData, isLoading, query.limit]);
 
   return (
-    <section className="flex flex-col gap-4 py-4">
+    <section className={cn("flex flex-col gap-4", { "py-4": !!href })}>
       <div className="flex items-center justify-start gap-3">
         <div className="max-w-2xl lg:max-w-4xl">
-          {title && <h2 className="text-2xl font-bold md:text-xl">{title}</h2>}
+          {title && <h2 className="font-bold text-xl">{title}</h2>}
         </div>
         {href && (
           <Link href={href}>

--- a/src/components/product/ProductSizes.tsx
+++ b/src/components/product/ProductSizes.tsx
@@ -1,0 +1,109 @@
+"use client";
+
+import { Product } from "@/types/payload";
+import { cn } from "@/utils";
+import { formatCategory } from "@/utils/product";
+import { useState } from "react";
+import Button from "../base/Button";
+
+interface SizeBoxProps {
+  size: number;
+  stock: number;
+  selected: boolean;
+  onSelect: () => void;
+}
+
+interface ProductSizeProps {
+  category: Product["category"];
+  availableSizes: Product["available_sizes"];
+}
+
+const SizeBox = ({ size, stock, selected, onSelect }: SizeBoxProps) => {
+  const baseStyle = `
+    flex items-center justify-center p-4 lg:max-w-12 lg:max-h-12
+    rounded-xl border border-primary-300 
+    bg-background 
+    font-semibold text-primary-700
+    hover:border-primary-400
+    cursor-pointer transition-color ease-in-out duration-300
+  `;
+
+  return (
+    <div
+      onClick={onSelect}
+      className={cn(baseStyle, {
+        "opacity-40 cursor-not-allowed": !stock,
+        "border-none bg-primary-900 text-background shadow-[0_2px_16px_-2px_rgba(33,36,39,0.50)]":
+          selected,
+      })}
+    >
+      {size}
+    </div>
+  );
+};
+
+const ProductSizes = ({ category, availableSizes }: ProductSizeProps) => {
+  // TODO: Update the type of the selectedSize to be an object so it can update the price accordingly
+  const [selectedSize, setSelectedSize] = useState<string>();
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex flex-col gap-4 p-5 bg-primary-100 rounded-2xl md:rounded-3xl border border-primary-300 shadow-[0_0_8px_1px_rgba(0,0,0,0.10)]">
+        <h4 className="font-semibold w-full">{`Select Sizes (US ${formatCategory(category)})`}</h4>
+        <hr className="border-primary-300 rounded-full" />
+
+        <ul className="grid grid-cols-5 gap-2 sm:grid-cols-7 md:grid-cols-9 lg:grid-cols-6 2xl:grid-cols-7 2xl:gap-1.5">
+          {availableSizes.map((item) => (
+            <SizeBox
+              key={item.id}
+              size={item.size}
+              stock={item.stock}
+              selected={item.id === selectedSize}
+              onSelect={() => setSelectedSize(item.id as string)}
+            />
+          ))}
+        </ul>
+
+        <div className="flex flex-col gap-2">
+          <Button
+            label="Add to cart"
+            disabled={!selectedSize}
+            iconPrepend="solar:cart-large-minimalistic-linear"
+          />
+          <Button
+            variant="ghost"
+            label="Wishlist sneaker"
+            iconPrepend="solar:heart-outline"
+          />
+        </div>
+      </div>
+
+      {/* TODO: Implement a modal that when this is clicked, shows the markup below */}
+      <span className="w-fit py-2 text-md underline underline-offset-4 cursor-pointer font-medium hover:text-secondary">
+        Can't find your size? Get notified!
+      </span>
+
+      {/* <div className="flex flex-col md:flex-row lg:flex-col items-center gap-y-2 gap-x-2">
+          <Input type="email" placeholder="Email address" />
+          <div className="flex flex-col sm:flex-row lg:flex-col 2xl:flex-row items-center gap-2 w-full">
+            <div className="w-full md:w-1/2 lg:w-full">
+              <Input
+                type="number"
+                placeholder="Size (US)"
+                min={3.5}
+                max={16}
+                step={0.5}
+              />
+            </div>
+            <Button
+              label="Notify me"
+              iconPrepend="gravity-ui:bell-dot"
+              className="w-full md:w-1/2 lg:w-full"
+            />
+          </div>
+        </div> */}
+    </div>
+  );
+};
+
+export default ProductSizes;

--- a/src/types/payload.ts
+++ b/src/types/payload.ts
@@ -68,7 +68,7 @@ export interface Model {
  */
 export interface Product {
   id: string;
-  createdBy?: (string | null) | User;
+  user?: (string | null) | User;
   sku: string;
   brand: string | Brand;
   model: string | Model;

--- a/src/utils/product.ts
+++ b/src/utils/product.ts
@@ -1,0 +1,41 @@
+import { Product } from "@/types/payload";
+
+export function getPriceInfo(product: Product) {
+  const minPriceInfo = product.available_sizes.reduce(
+    (min, size) => {
+      const regularPrice = size.price ?? Infinity;
+      const discountedPrice = size.discount
+        ? regularPrice * (1 - size.discount)
+        : regularPrice;
+
+      if (discountedPrice < min.discountedPrice) {
+        return { regularPrice, discountedPrice };
+      }
+
+      return min;
+    },
+    { regularPrice: Infinity, discountedPrice: Infinity }
+  );
+
+  return {
+    regularPrice: minPriceInfo.regularPrice,
+    discountedPrice:
+      minPriceInfo.discountedPrice !== minPriceInfo.regularPrice
+        ? minPriceInfo.discountedPrice
+        : null,
+  };
+}
+
+export function getProductInfo(product: Product) {
+  const brand =
+    typeof product.brand === "string" ? product.brand : product.brand.name;
+  const model =
+    typeof product.model === "string" ? product.model : product.model.name;
+
+  return { brand, model };
+}
+
+export function formatCategory(category: Product["category"]) {
+  if (!category) return "";
+  return category.charAt(0).toUpperCase() + category.slice(1);
+}

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -8,12 +8,16 @@ const config: Config = {
   ],
   theme: {
     extend: {
+      screens: {
+        "2xl": "1440px",
+        "3xl": "1536px",
+      },
       colors: {
         background: "#ffffff",
         foreground: "#212427",
         primary: {
           50: "#ffffff",
-          100: "#fafbfb",
+          100: "#f9fafb",
           200: "#f2f2f2",
           300: "#ebebeb",
           400: "#bebfc0",


### PR DESCRIPTION
## Changelog

### Features
- Added a new route to access the details of a product, such as details, price, sizes, a carousel for product images, and so on.
- Implemented helper functions that return data about the product so they can be reused in product components, thus removing duplicated logic.

## Tech Setup
- Added a new breakpoint in the `tailwind.config.ts` file to support devices with a screen width of `1440px`.

### UI & Refactors
- Adjusted `MainContainer` to stretch up to the newly added breakpoint.
- Added a light shadow to the `Navbar` to distinguish it from other components.
- Adjusted `ProductReel` vertical padding to show when a `href` is provided.
- The cover image of the `ProductCard` will show as a square in smaller devices.
- Created a reusable `Accordion` component.
- Extracted `Breadcrumbs` into a reusable component if needed in the future.

